### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,7 @@
 cff-version: 1.2.0
 title: "Climate assessment of long-term emissions pathways: IPCC AR6 WGIII version"
 message: >-
-  If you use this software, please cite it using the
-  metadata from this file.
+  If you use this software, please cite it using the metadata from this file.
 type: software
 authors:
   - given-names: Jarmo S.
@@ -32,3 +31,12 @@ authors:
   - family-names: Hackstock
     given-names: Philip
     orcid: 'https://orcid.org/0000-0002-1482-1366'
+repository-code: 'https://github.com/iiasa/climate-assessment'
+license: MIT
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.6624519
+    description: The concept DOI of the work.
+  - type: doi
+    value: 10.5281/zenodo.6624520
+    description: The versioned DOI for version 0.1.0 of the work.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 cff-version: 1.2.0
-title: WG3 Climate assessment
+title: "Climate assessment of long-term emissions pathways: IPCC AR6 WGIII version"
 message: >-
   If you use this software, please cite it using the
   metadata from this file.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -34,9 +34,9 @@ authors:
 repository-code: 'https://github.com/iiasa/climate-assessment'
 license: MIT
 identifiers:
-  - type: doi
-    value: 10.5281/zenodo.6624519
-    description: The concept DOI of the work.
-  - type: doi
+  - description: The concept DOI of the work.
+    type: doi
+    value: 10.5281/zenodo.6624519    
+  - description: The versioned DOI for version 0.1.0 of the work.
+    type: doi
     value: 10.5281/zenodo.6624520
-    description: The versioned DOI for version 0.1.0 of the work.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,34 @@
+cff-version: 1.2.0
+title: WG3 Climate assessment
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Jarmo
+    family-names: Kikstra
+    email: kikstra@iiasa.ac.at
+    affiliation: IIASA
+    orcid: 'https://orcid.org/0000-0001-9405-1228'
+  - given-names: Zebedee R.J.
+    family-names: Nicholls
+    orcid: 'https://orcid.org/0000-0002-4767-2723'
+  - given-names: Jared
+    family-names: Lewis
+    orcid: 'https://orcid.org/0000-0002-8155-8924'
+  - given-names: Christopher J.
+    family-names: Smith
+    orcid: 'https://orcid.org/0000-0003-0599-4633'
+  - family-names: Lamboll
+    given-names: Robin D.
+  - family-names: Byers
+    given-names: Edward
+    orcid: 'https://orcid.org/0000-0003-0349-5742'
+  - family-names: Sandstad
+    given-names: Marit
+  - given-names: Laura
+    family-names: Wienpahl
+    orcid: 'https://orcid.org/0000-0003-2049-8531'
+  - family-names: Hackstock
+    given-names: Philip
+    orcid: 'https://orcid.org/0000-0002-1482-1366'

--- a/README.rst
+++ b/README.rst
@@ -3,15 +3,14 @@ WG3 Climate assessment
 `ar6climate` provides the possibility to reproduce the climate variable data for the working group III (WGIII or WG3) contribution to the IPCC Sixth Assessment (AR6) report, using climate emulators that were used in the working group I (WGI or WG1) contribution to AR6.
 It also allows for assessing new emissions pathways in a way that is fully consistent with AR6.
 
-For the documentation of this package, please go to: [TODO move to public read the docs e.g. climate-assessment.readthedocs.io] https://iiasa-energy-program-climate-assessment.readthedocs-hosted.com/en/latest/.
+For the documentation of this package, please go to: https://climate-assessment.readthedocs.io/.
 
 .. sec-begin-license
 
 License
 -------
 
-The WG3 climate assessment workflow license is currently under discussion.
-Please do not distribute or use until then.
+The WG3 climate assessment workflow license is distributed under the MIT license.
 
 .. sec-end-license
 


### PR DESCRIPTION
Adding a `CITATION.cff` file so that it will be picked up by Zenodo for future releases.
For `v0.1.0` I'll manually add the authors.
The authors are taken from `setup.cfg`.