### PR TITLE
Update classifier in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.9
-    Topic :: Climate Science
+    Topic :: Scientific/Engineering :: Atmospheric Science
 
 [options]
 packages = find:


### PR DESCRIPTION
Update the classifier `Topic :: Climate Science` to the closest allowed value by pypi, `Topic :: Scientific/Engineering :: Atmospheric Science` (list of all allowed classifiers: https://pypi.org/classifiers/). This is necessary to be able to upload to pypi. 
Not sure this needs any of the usual PR steps.

- [ ] ~~Tests added~~
- [ ]  ~~Documentation added~~
- [ ]  ~~Example added (in the documentation, to an existing notebook, or in a new notebook)~~
- [ ]  ~~Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/iiasa/climate-assessment/pull/XX>`_) Added feature which does something``)~~
