### PR TITLE
Update awscli to >= 1.29.4 for pyyaml 6.0 support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ master
 
 Added
 ~~~~~
+- (`#40 https://github.com/iiasa/climate-assessment/pull/40`_) Update awscli to >= 1.29.4
 - (`#31 https://github.com/iiasa/climate-assessment/pull/31`_) Update pyam-iamc to >=1.7.0
 - (`#15 <https://github.com/iiasa/climate-assessment/pull/15>`_) Fix packaging issues and add installation instructions
 - (`#6 <https://github.com/iiasa/climate-assessment/pull/6>`_) Added example run notebooks and tests thereof

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ package_dir =
 include_package_data = True
 install_requires =
     aneris-iamc==0.3.1
-    awscli==1.27.134
+    awscli>=1.28
     click
     fair==1.6.2
     importlib-metadata

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ package_dir =
 include_package_data = True
 install_requires =
     aneris-iamc==0.3.1
-    awscli>=1.28
+    awscli>=1.29.4
     click
     fair==1.6.2
     importlib-metadata


### PR DESCRIPTION
This PR updates the `awscli` dependency to >=1.29.4. 
Reason for that is that at this version number pyyaml 6.0 is supported. 
This is important because after the most recent update of cython, pyyaml < 6.0 no longer works.


- [ ] ~~Tests added~~
- [ ] ~~Documentation added~~
- [ ] ~~Example added (in the documentation, to an existing notebook, or in a new notebook)~~
- [x] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/iiasa/climate-assessment/pull/XX>`_) Added feature which does something``)

@jkikstra or @znicholls a quick review would me much appreciated since this is currently blocking me from updating our processing containers. 