### PR TITLE
Added save_csv_combined_output option

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ master
 
 Added
 ~~~~~
+- (`#40 https://github.com/iiasa/climate-assessment/pull/43`_) Added CSV option to :func:`climate_assessment.cli.clim_cli`
 - (`#40 https://github.com/iiasa/climate-assessment/pull/40`_) Update awscli to >= 1.29.4
 - (`#36 https://github.com/iiasa/climate-assessment/pull/36`_) Update pyam-iamc to >=1.9.0
 - (`#31 https://github.com/iiasa/climate-assessment/pull/31`_) Update pyam-iamc to >=1.7.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ master
 
 Added
 ~~~~~
-- (`#40 https://github.com/iiasa/climate-assessment/pull/43`_) Added CSV option to :func:`climate_assessment.cli.clim_cli`
+- (`#40 https://github.com/iiasa/climate-assessment/pull/43`_) Add combined CSV output option to :func:`climate_assessment.cli.clim_cli`
 - (`#40 https://github.com/iiasa/climate-assessment/pull/40`_) Update awscli to >= 1.29.4
 - (`#36 https://github.com/iiasa/climate-assessment/pull/36`_) Update pyam-iamc to >=1.9.0
 - (`#31 https://github.com/iiasa/climate-assessment/pull/31`_) Update pyam-iamc to >=1.7.0

--- a/src/climate_assessment/cli.py
+++ b/src/climate_assessment/cli.py
@@ -245,7 +245,15 @@ harmonize_option = click.option(
     type=bool,
     show_default=True,
 )
-
+save_csv_combined_output_option = click.option(
+    "--save-csv-combined-output",
+    help="Write CSV output with combined climate output and emissions",
+    is_flag=True,
+    required=False,
+    default=False,
+    type=bool,
+    show_default=True,
+)
 
 def _setup_logging(logger):
     """
@@ -880,6 +888,7 @@ def infill(
 @gwp_def_false_option
 @nonco2_warming_option
 @save_raw_climate_output_option
+@save_csv_combined_output_option
 def clim_cli(
     harmonizedinfilledemissions,
     outdir,
@@ -898,6 +907,8 @@ def clim_cli(
     gwp,
     co2_and_non_co2_warming,
     save_raw_climate_output,
+    save_csv_combined_output
+
 ):
     """
     Run the climate emulator step of the IPCC AR6 climate asessment workflow.
@@ -967,6 +978,10 @@ def clim_cli(
 
     LOGGER.info("write out raw output")
     results.to_excel(os.path.join(outdir, str(key_string + "_" + "rawoutput.xlsx")))
+    
+    if save_csv_combined_output:
+        LOGGER.info("write out raw output in csv")
+        results.to_csv(os.path.join(outdir, str(key_string + "_" + "rawoutput.csv")))
 
     LOGGER.info("COMPLETE")
 

--- a/src/climate_assessment/cli.py
+++ b/src/climate_assessment/cli.py
@@ -255,6 +255,7 @@ save_csv_combined_output_option = click.option(
     show_default=True,
 )
 
+
 def _setup_logging(logger):
     """
     Set up logging preferences. This removes unnecessary logger warnings from
@@ -907,8 +908,7 @@ def clim_cli(
     gwp,
     co2_and_non_co2_warming,
     save_raw_climate_output,
-    save_csv_combined_output
-
+    save_csv_combined_output,
 ):
     """
     Run the climate emulator step of the IPCC AR6 climate asessment workflow.
@@ -978,7 +978,7 @@ def clim_cli(
 
     LOGGER.info("write out raw output")
     results.to_excel(os.path.join(outdir, str(key_string + "_" + "rawoutput.xlsx")))
-    
+
     if save_csv_combined_output:
         LOGGER.info("write out raw output in csv")
         results.to_csv(os.path.join(outdir, str(key_string + "_" + "rawoutput.csv")))

--- a/tests/integration/test_run_clim_integration.py
+++ b/tests/integration/test_run_clim_integration.py
@@ -248,4 +248,4 @@ def test_combined_csv_output(
     assert os.path.isfile(out_xls_fname), "XLS output not written"
     assert os.path.isfile(
         out_csv_fname
-    ), "--save-csv-combined-output was set but CSV output not written:"
+    ), "--save-csv-combined-output was set but CSV output not written"

--- a/tests/integration/test_run_clim_integration.py
+++ b/tests/integration/test_run_clim_integration.py
@@ -245,7 +245,7 @@ def test_combined_csv_output(
     out_csv_fname = os.path.join(out_dir, "ex2_harmonized_infilled_rawoutput.csv")
     out_xls_fname = os.path.join(out_dir, "ex2_harmonized_infilled_rawoutput.xlsx")
 
-    assert os.path.isfile(out_xls_fname), "XLS output not written:"
+    assert os.path.isfile(out_xls_fname), "XLS output not written"
     assert os.path.isfile(
         out_csv_fname
     ), "--save-csv-combined-output was set but CSV output not written:"

--- a/tests/integration/test_run_clim_integration.py
+++ b/tests/integration/test_run_clim_integration.py
@@ -202,6 +202,7 @@ def test_historical_eval_period_out_of_order(
         "less than or equal to the second), we received 2014-1995"
     )
 
+
 def test_output_written(
     tmpdir, test_data_dir, fair_slim_configs_filepath, fair_common_configs_filepath
 ):
@@ -235,12 +236,16 @@ def test_output_written(
             4,
             "--historical-warming",
             0.8,
-            "--save-csv-combined-output"
+            "--save-csv-combined-output",
         ],
     )
+
+    assert result.exit_code == 0, _format_traceback_and_stdout_from_click_result(result)
 
     out_csv_fname = os.path.join(out_dir, "ex2_harmonized_infilled_rawoutput.csv")
     out_xls_fname = os.path.join(out_dir, "ex2_harmonized_infilled_rawoutput.xlsx")
 
-    assert os.path.isfile(out_xls_fname), f"XLS output not written:"
-    assert os.path.isfile(out_csv_fname), f"--save-csv-combined-output was set but CSV output not written:"
+    assert os.path.isfile(out_xls_fname), "XLS output not written:"
+    assert os.path.isfile(
+        out_csv_fname
+    ), "--save-csv-combined-output was set but CSV output not written:"

--- a/tests/integration/test_run_clim_integration.py
+++ b/tests/integration/test_run_clim_integration.py
@@ -203,7 +203,7 @@ def test_historical_eval_period_out_of_order(
     )
 
 
-def test_output_written(
+def test_combined_csv_output(
     tmpdir, test_data_dir, fair_slim_configs_filepath, fair_common_configs_filepath
 ):
     out_dir = str(tmpdir)

--- a/tests/integration/test_run_clim_integration.py
+++ b/tests/integration/test_run_clim_integration.py
@@ -201,3 +201,46 @@ def test_historical_eval_period_out_of_order(
         "`period` must be a string of the form 'YYYY-YYYY' (with the first year being "
         "less than or equal to the second), we received 2014-1995"
     )
+
+def test_output_written(
+    tmpdir, test_data_dir, fair_slim_configs_filepath, fair_common_configs_filepath
+):
+    out_dir = str(tmpdir)
+    inp_file = os.path.join(
+        test_data_dir,
+        "workflow-fair",
+        "ex2_harmonized_infilled.csv",
+    )
+
+    fair_version = "1.6.2"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        climate_assessment.cli.clim_cli,
+        [
+            inp_file,
+            out_dir,
+            "--num-cfgs",
+            1,
+            "--test-run",
+            "--model",
+            "fair",
+            "--model-version",
+            fair_version,
+            "--probabilistic-file",
+            fair_slim_configs_filepath,
+            "--fair-extra-config",
+            fair_common_configs_filepath,
+            "--scenario-batch-size",
+            4,
+            "--historical-warming",
+            0.8,
+            "--save-csv-combined-output"
+        ],
+    )
+
+    out_csv_fname = os.path.join(out_dir, "ex2_harmonized_infilled_rawoutput.csv")
+    out_xls_fname = os.path.join(out_dir, "ex2_harmonized_infilled_rawoutput.xlsx")
+
+    assert os.path.isfile(out_xls_fname), f"XLS output not written:"
+    assert os.path.isfile(out_csv_fname), f"--save-csv-combined-output was set but CSV output not written:"


### PR DESCRIPTION
Hi all,

We at PIK have started integrating `climate-assessment` in some of our workflows, such as in the REMIND model. For that, adding some minor new features to the package would be really helpful, which I aim to implement. I don't know what's your policy for that, but in case PRs are the proper channel, here's one.

It simply adds an option in `clim_cli` to also write raw output as CSV besides the XLSX standard. Reading excel can be pretty cumbersome for some of our applications. 

All tests in `tests/integration` have passed, is this sufficient for a PR?

Thank you regardless, and please let me know if I should be using another channel for this,
Gabriel

- [ ] Tests added
- [x] Documentation added
- [ ] Example added (in the documentation, to an existing notebook, or in a new notebook)
- [x] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/iiasa/climate-assessment/pull/XX>`_) Added feature which does something``)
